### PR TITLE
fix(annotation): replaced ---@module with ---@meta

### DIFF
--- a/doc/mega_vimdoc_api.txt
+++ b/doc/mega_vimdoc_api.txt
@@ -5,13 +5,15 @@ The file that auto-creates documentation for `mega.vimdoc`.
 ------------------------------------------------------------------------------
                                         *mega.vimdoc.make_documentation_files()*
 
-`mega.vimdoc.make_documentation_files`({paths})
+`mega.vimdoc.make_documentation_files`({paths}, {options})
 
 Convert the files in this plug-in from Lua docstrings to Vimdoc documentation.
 
 Parameters ~
     {paths} mega.vimdoc.AutoDocumentationEntry[]
        All of the source + destination pairs to process.
+    {options} mega.vimdoc.AutoDocumentationOptions?
+       Customize the output using these settings, if needed.
 
 
 WARNING: This file is auto-generated. Do not edit it!

--- a/doc/mega_vimdoc_types.txt
+++ b/doc/mega_vimdoc_types.txt
@@ -14,6 +14,15 @@ Fields ~
        An absolute path for the auto-created documentation.
        e.g. `"/out/mega_vimdoc.txt"`.
 
+------------------------------------------------------------------------------
+*mega.vimdoc.AutoDocumentationOptions*
+   Customize the documentation output using these settings, if needed.
+
+Fields ~
+    {enable_module_in_signature} `(boolean?)`
+       If `true`, a function signature like `M.bar(value)` will have its "M"
+       replaced with the actual module name like `foo.bar(value)`.
+
 
 WARNING: This file is auto-generated. Do not edit it!
 

--- a/doc/tags
+++ b/doc/tags
@@ -11,5 +11,6 @@ mega.vimdoc-tests-initialization	mega.vimdoc.txt	/*mega.vimdoc-tests-initializat
 mega.vimdoc-tests-running	mega.vimdoc.txt	/*mega.vimdoc-tests-running*
 mega.vimdoc-tracking-updates	mega.vimdoc.txt	/*mega.vimdoc-tracking-updates*
 mega.vimdoc.AutoDocumentationEntry	mega_vimdoc_types.txt	/*mega.vimdoc.AutoDocumentationEntry*
+mega.vimdoc.AutoDocumentationOptions	mega_vimdoc_types.txt	/*mega.vimdoc.AutoDocumentationOptions*
 mega.vimdoc.make_documentation_files()	mega_vimdoc_api.txt	/*mega.vimdoc.make_documentation_files()*
 mega.vimdoc.txt	mega.vimdoc.txt	/*mega.vimdoc.txt*

--- a/lua/mega/vimdoc/_vendors/logging.lua
+++ b/lua/mega/vimdoc/_vendors/logging.lua
@@ -1,7 +1,4 @@
 --- The internal logger - Use the supported dependency or our own.
----
----@module 'mega.vimdoc._vendors.logging'
----
 
 local success, logging = pcall(function()
     return require("mega.logging")
@@ -15,8 +12,4 @@ if not logging then
     error("Can't continue - no logging module could be found!")
 end
 
-local M = {}
-
-M.get_logger = logging.get_logger
-
-return M
+return logging

--- a/lua/mega/vimdoc/init.lua
+++ b/lua/mega/vimdoc/init.lua
@@ -1,7 +1,4 @@
 --- The file that auto-creates documentation for `mega.vimdoc`.
----
----@module 'mega.vimdoc'
----
 
 local M = {}
 
@@ -9,11 +6,13 @@ local M = {}
 ---
 ---@param paths mega.vimdoc.AutoDocumentationEntry[]
 ---    All of the source + destination pairs to process.
+---@param options mega.vimdoc.AutoDocumentationOptions?
+---    Customize the output using these settings, if needed.
 ---
-function M.make_documentation_files(paths)
+function M.make_documentation_files(paths, options)
     local core = require("mega.vimdoc._core")
 
-    core.make_documentation_files(paths)
+    core.make_documentation_files(paths, options)
 end
 
 return M

--- a/lua/mega/vimdoc/minidoc_stub.lua
+++ b/lua/mega/vimdoc/minidoc_stub.lua
@@ -1,7 +1,4 @@
 --- Fake documentation for 'mini.doc', which doesn't have explicit types.
----
----@module 'mini.doc'
----
 
 ---@class MiniDoc.Hooks
 ---    Customization options during documentation generation. It can control

--- a/lua/mega/vimdoc/types.lua
+++ b/lua/mega/vimdoc/types.lua
@@ -1,7 +1,4 @@
 --- All types needed for `mega.vimdoc` to work as expected.
----
----@module 'mega.vimdoc.type'
----
 
 ---@class mega.vimdoc.AutoDocumentationEntry
 ---    The simple source/destination of "Lua file that we want to auto-create
@@ -11,3 +8,9 @@
 ---@field destination string
 ---    An absolute path for the auto-created documentation.
 ---    e.g. `"/out/mega_vimdoc.txt"`.
+
+---@class mega.vimdoc.AutoDocumentationOptions
+---    Customize the documentation output using these settings, if needed.
+---@field enable_module_in_signature boolean?
+---    If `true`, a function signature like `M.bar(value)` will have its "M"
+---    replaced with the actual module name like `foo.bar(value)`.

--- a/spec/mega_vimdoc/module_discovery_spec.lua
+++ b/spec/mega_vimdoc/module_discovery_spec.lua
@@ -1,0 +1,381 @@
+--- Make sure "automatically find the module for a `require`" works.
+
+local common = require("test_utilities.common")
+local logging = require("mega.vimdoc._vendors.logging")
+local vimdoc = require("mega.vimdoc")
+
+local _PACKAGE_PATH = ""
+local _RUNTIMEPATH = ""
+---@type string[]
+local _PACKAGES_TO_UNLOAD = {}
+
+--- Reset all dependencies and clean up and temporary files / directories.
+local function _after_each()
+    common.reset_mini_doc()
+    common.delete_temporary_data()
+end
+
+--- Remember the current `:help 'runtimepath'` so it can be reverted later.
+local function _keep_neovim_runtime()
+    _RUNTIMEPATH = vim.fn.copy(vim.o.runtimepath)
+end
+
+--- Make a file on-disk at `path`.
+---
+--- Raises:
+---     If `path` is not writeable for some reason.
+---
+---@param path string An absolute path where a new file (probably a file file) will go.
+---@param data string A blob of text to write into the `path`.
+---
+local function _make_fake_file(path, data)
+    local directory = vim.fs.dirname(path)
+
+    if vim.fn.isdirectory(directory) ~= 1 then
+        vim.fn.mkdir(directory, "p")
+    end
+
+    local file = io.open(path, "w")
+
+    if not file then
+        error(string.format('Path "%s" cannot be written to.', path), 0)
+    end
+
+    file:write(data)
+    file:close()
+end
+
+--- Add `directory` to the start of `:help 'runtimepath'` so that we can import it.
+---
+---@param directory string An absolute path on-disk to a Neovim plugin.
+---
+local function _prepend_to_runtimepath(directory)
+    if not vim.o.runtimepath or vim.o.runtimepath == "" then
+        vim.o.runtimepath = directory
+
+        return
+    end
+
+    local separator = ","
+    vim.o.runtimepath = directory .. separator .. vim.o.runtimepath
+end
+
+--- Read the file contents of `path`.
+---
+--- Raises:
+---     If `path` is unreadable.
+---
+---@param path string An absolute path on-disk.
+---@return string # The found text.
+---
+local function _read_file_data(path)
+    local file = io.open(path, "r")
+
+    if not file then
+        error(string.format('Path "%s" cannot be read.', path))
+    end
+
+    local data = file:read("*a")
+
+    file:close()
+
+    return data
+end
+
+--- Get the saved `:help 'runtimepath'` and apply it back to the current environment.
+local function _restore_neovim_runtime()
+    vim.o.runtimepath = _RUNTIMEPATH
+
+    for _, namespace in ipairs(_PACKAGES_TO_UNLOAD) do
+        package.loaded[namespace] = nil
+    end
+end
+
+before_each(function()
+    logging.set_configuration(nil, { use_console = false })
+    common.silence_mini_doc()
+end)
+
+after_each(_after_each)
+
+describe("module discovery", function()
+    before_each(function()
+        _PACKAGE_PATH = vim.fn.copy(package.path)
+    end)
+    after_each(function()
+        package.path = _PACKAGE_PATH
+    end)
+
+    describe("lua", function()
+        it("works when a path is found in Lua's LUA_CPATH", function()
+            local root = vim.fs.normalize(common.make_temporary_path())
+            local plugin = vim.fs.joinpath(root, "my_fake_neovim_plugin")
+            local path = vim.fs.joinpath(plugin, "lua", "foo.lua")
+
+            package.path = vim.fs.joinpath(plugin, "lua", "?.lua")
+            _make_fake_file(
+                path,
+                [[
+local M = {}
+
+---@param value string Some data to do things with.
+---@return integer # Some return text.
+function M.bar(value) end
+
+return M
+]]
+            )
+
+            table.insert(_PACKAGES_TO_UNLOAD, "foo")
+
+            local success, _ = pcall(function()
+                require("foo")
+            end)
+            assert.is_true(success)
+
+            local destination = vim.fs.joinpath(common.make_temporary_path(), "inner_folder", "destination.lua")
+            vimdoc.make_documentation_files({ { source = path, destination = destination } })
+
+            local found = _read_file_data(destination)
+
+            assert.equal(
+                [[
+==============================================================================
+------------------------------------------------------------------------------
+                                                                     *foo.bar()*
+
+`foo.bar`({value})
+
+Parameters ~
+    {value} `(string)` Some data to do things with.
+
+Return ~
+    `(integer)` Some return text.
+
+
+WARNING: This file is auto-generated. Do not edit it!
+
+ vim:tw=78:ts=8:noet:ft=help:norl:]],
+                found
+            )
+        end)
+    end)
+
+    describe("neovim runtimepath", function()
+        before_each(_keep_neovim_runtime)
+        after_each(_restore_neovim_runtime)
+
+        it("works with a Lua file in a Neovim plugin", function()
+            local root = common.make_temporary_path()
+            local plugin = vim.fs.joinpath(root, "my_fake_neovim_plugin")
+            local path = vim.fs.joinpath(plugin, "lua", "foo.lua")
+
+            _prepend_to_runtimepath(plugin)
+            _make_fake_file(
+                path,
+                [[
+local M = {}
+
+---@param value string Some data to do things with.
+---@return integer # Some return text.
+function M.bar(value) end
+
+return M
+]]
+            )
+
+            table.insert(_PACKAGES_TO_UNLOAD, "foo")
+
+            local success, _ = pcall(function()
+                require("foo")
+            end)
+            assert.is_true(success)
+
+            local destination = vim.fs.joinpath(common.make_temporary_path(), "inner_folder", "destination.lua")
+            vimdoc.make_documentation_files({ { source = path, destination = destination } })
+
+            local found = _read_file_data(destination)
+
+            assert.equal(
+                [[
+==============================================================================
+------------------------------------------------------------------------------
+                                                                     *foo.bar()*
+
+`foo.bar`({value})
+
+Parameters ~
+    {value} `(string)` Some data to do things with.
+
+Return ~
+    `(integer)` Some return text.
+
+
+WARNING: This file is auto-generated. Do not edit it!
+
+ vim:tw=78:ts=8:noet:ft=help:norl:]],
+                found
+            )
+        end)
+
+        it("works with a init.lua in a Neovim plugin", function()
+            local root = common.make_temporary_path()
+            local plugin = vim.fs.joinpath(root, "my_fake_neovim_plugin")
+            local path = vim.fs.joinpath(plugin, "lua", "foo", "init.lua")
+
+            _prepend_to_runtimepath(plugin)
+            _make_fake_file(
+                path,
+                [[
+local M = {}
+
+---@param value string Some data to do things with.
+---@return integer # Some return text.
+function M.bar(value) end
+
+return M
+]]
+            )
+
+            table.insert(_PACKAGES_TO_UNLOAD, "foo")
+
+            local success, _ = pcall(function()
+                require("foo")
+            end)
+            assert.is_true(success)
+
+            local destination = vim.fs.joinpath(common.make_temporary_path(), "inner_folder", "destination.lua")
+            vimdoc.make_documentation_files({ { source = path, destination = destination } })
+
+            local found = _read_file_data(destination)
+
+            assert.equal(
+                [[
+==============================================================================
+------------------------------------------------------------------------------
+                                                                     *foo.bar()*
+
+`foo.bar`({value})
+
+Parameters ~
+    {value} `(string)` Some data to do things with.
+
+Return ~
+    `(integer)` Some return text.
+
+
+WARNING: This file is auto-generated. Do not edit it!
+
+ vim:tw=78:ts=8:noet:ft=help:norl:]],
+                found
+            )
+        end)
+
+        it("works with an inner Lua file in a Neovim plugin", function()
+            local root = common.make_temporary_path()
+            local plugin = vim.fs.joinpath(root, "my_fake_neovim_plugin")
+            local path = vim.fs.joinpath(plugin, "lua", "foo", "fizz.lua")
+
+            _prepend_to_runtimepath(plugin)
+            _make_fake_file(
+                path,
+                [[
+local M = {}
+
+---@param value string Some data to do things with.
+---@return integer # Some return text.
+function M.bar(value) end
+
+return M
+]]
+            )
+
+            table.insert(_PACKAGES_TO_UNLOAD, "foo")
+
+            local success, _ = pcall(function()
+                require("foo.fizz")
+            end)
+            assert.is_true(success)
+
+            local destination = vim.fs.joinpath(common.make_temporary_path(), "inner_folder", "destination.lua")
+            vimdoc.make_documentation_files({ { source = path, destination = destination } })
+
+            local found = _read_file_data(destination)
+
+            assert.equal(
+                [[
+==============================================================================
+------------------------------------------------------------------------------
+                                                                *foo.fizz.bar()*
+
+`foo.fizz.bar`({value})
+
+Parameters ~
+    {value} `(string)` Some data to do things with.
+
+Return ~
+    `(integer)` Some return text.
+
+
+WARNING: This file is auto-generated. Do not edit it!
+
+ vim:tw=78:ts=8:noet:ft=help:norl:]],
+                found
+            )
+        end)
+    end)
+
+    describe("generic", function()
+        it("fails if the path is not findable", function()
+            local root = common.make_temporary_path()
+            local plugin = vim.fs.joinpath(root, "my_fake_neovim_plugin")
+            local path = vim.fs.joinpath(plugin, "lua", "foo", "fizz.lua")
+
+            _make_fake_file(
+                path,
+                [[
+local M = {}
+
+---@param value string Some data to do things with.
+---@return integer # Some return text.
+function M.bar(value) end
+
+return M
+]]
+            )
+
+            table.insert(_PACKAGES_TO_UNLOAD, "foo")
+
+            local success, _ = pcall(function()
+                require("foo.fizz")
+            end)
+            assert.is_true(success)
+
+            local destination = vim.fs.joinpath(common.make_temporary_path(), "inner_folder", "destination.lua")
+            vimdoc.make_documentation_files({ { source = path, destination = destination } })
+
+            local found = _read_file_data(destination)
+
+            assert.equal(
+                [[
+==============================================================================
+------------------------------------------------------------------------------
+                                                                       *M.bar()*
+
+`bar`({value})
+
+Parameters ~
+    {value} `(string)` Some data to do things with.
+
+Return ~
+    `(integer)` Some return text.
+
+
+WARNING: This file is auto-generated. Do not edit it!
+
+ vim:tw=78:ts=8:noet:ft=help:norl:]],
+                found
+            )
+        end)
+    end)
+end)

--- a/spec/test_utilities/common.lua
+++ b/spec/test_utilities/common.lua
@@ -1,0 +1,71 @@
+--- Simple functions to make writing unittests easier.
+
+local M = {}
+
+local _COUNTER = 1
+---@type string[]
+local _DELETE_LATER = {}
+local _ORIGINAL_VIM_NOTIFY = vim.notify
+
+--- Delete all files / folders that were created during unittesting.
+function M.delete_temporary_data()
+    for _, path in ipairs(_DELETE_LATER) do
+        vim.fn.delete(path, "rf")
+    end
+
+    _DELETE_LATER = {}
+end
+
+if vim.fn.has("win32") == 1 then
+    -- NOTE: GitHub actions place temp files in a directory, C:\Users\RUNNER~1,
+    -- that Vim doesn't know how to read. So we need to redirect that temporary
+    -- directory that gets created.
+
+    --- Make a file ending in `suffix`.
+    ---
+    ---@param suffix string? An ending name / file extension. e.g. `".lua"`.
+    ---@return string # The file path on-disk that Vim made.
+    ---
+    M.make_temporary_path = function(suffix)
+        -- NOTE: We need just the string for a directory name.
+        local directory = os.tmpname()
+        vim.fn.delete(directory)
+        directory = vim.fs.joinpath(vim.fn.getcwd(), ".tmp.mega.vimdoc", vim.fs.basename(directory))
+
+        local path = vim.fs.joinpath(directory, tostring(_COUNTER) .. (suffix or ""))
+        table.insert(_DELETE_LATER, directory)
+        _COUNTER = _COUNTER + 1
+
+        return path
+    end
+else
+    --- Make a file ending in `suffix`.
+    ---
+    ---@param suffix string? An ending name / file extension. e.g. `".lua"`.
+    ---@return string # The file path on-disk that Vim made.
+    ---
+    M.make_temporary_path = function(suffix)
+        -- NOTE: We need just the string for a directory name.
+        local directory = os.tmpname()
+        vim.fn.delete(directory)
+
+        local path = vim.fs.joinpath(directory, tostring(_COUNTER) .. (suffix or ""))
+        table.insert(_DELETE_LATER, directory)
+        _COUNTER = _COUNTER + 1
+
+        return path
+    end
+end
+
+--- Stop mini.doc from printing during unittests.
+function M.silence_mini_doc()
+    ---@diagnostic disable-next-line: duplicate-set-field
+    vim.notify = function() end
+end
+
+--- Revert any mocks before unittests were ran.
+function M.reset_mini_doc()
+    vim.notify = _ORIGINAL_VIM_NOTIFY
+end
+
+return M


### PR DESCRIPTION
Apparently I'd been using `---@module` all wrong. According to the LuaLS annotation documentation ... 

https://luals.github.io/wiki/annotations/#module

Basically adding `---@module` makes the next variable as a "module" type. There is another annotation called `@meta` however that isn't right either. `@meta` is to indicate when you have a type-hint .lua file (that has no actual contents / definition). If you add `@meta` to a file it has implications on LuaLS features. See https://luals.github.io/wiki/annotations/#meta

Anyway, we shouldn't use `@module` and can't use `@meta`. So instead we now discover the Lua plugin path automatically, using `:help 'runtimepath'`.

And in the process of getting that working, I noticed `lua/mega/vimdoc/_vendors/_logging.lua` has some issues so I fixed them over at https://github.com/ColinKennedy/mega.logging/pull/17 and copied the equivalent settings here.

And that's this PR in a nutshell