### PR TITLE
fix + feature: `@class` and module identifiers now render correctly

### DIFF
--- a/doc/news.txt
+++ b/doc/news.txt
@@ -1,13 +1,12 @@
 *mega.vimdoc-news.txt*
 
-Notable changes since mega.vimdoc 1.0
+Notable changes since mega.vimdoc 1.1
 
 
 ===============================================================================
 NEW FEATURES                                     *mega.vimdoc-new-features*
 
-- Fast navigation to custom types is now supported.
-    - See `:help CTRL-]` for details.
+- namespaced class and functions are now auto-hidden
 
 
 ===============================================================================

--- a/spec/mega_vimdoc/mega_vimdoc_spec.lua
+++ b/spec/mega_vimdoc/mega_vimdoc_spec.lua
@@ -101,6 +101,61 @@ Return ~
         )
     end)
 
+    it("hides private functions by default if they are not return-ed", function()
+        _run_test(
+            [[
+local _P = {}
+local M = {}
+
+---@class FooThing
+---    I am a Foo description.
+M.Foo = {}
+
+---@class BarThing
+---    I am a Bar description.
+_P.Bar = {}
+
+---@return integer # Blah.
+function _P.bar()
+end
+
+---@return integer # Blah.
+local function thing()
+end
+
+---@return integer # Blah.
+function M.foo()
+end
+
+---@return integer # Blah.
+---@private
+function M.another()
+end
+
+return M
+            ]],
+            [[
+==============================================================================
+------------------------------------------------------------------------------
+                                                                         *M.Foo*
+
+`Foo`
+
+*FooThing*
+   I am a Foo description.
+
+------------------------------------------------------------------------------
+                                                                       *M.foo()*
+
+`foo`()
+
+
+Return ~
+    `(integer)` Blah.
+]]
+        )
+    end)
+
     it("hides the module name from the signature if disabled", function()
         _run_test(
             [[
@@ -270,6 +325,21 @@ Return ~
 end)
 
 describe("@class", function()
+    it("works with base class inheritance #current", function()
+        _run_test(
+            [[
+---@class Foo : SomeOtherBaseClass
+---    I am a Foo class!
+            ]],
+            [[
+==============================================================================
+------------------------------------------------------------------------------
+*Foo*
+   I am a Foo class!
+]]
+        )
+    end)
+
     it("works with metatable definitions", function()
         _run_test(
             [[


### PR DESCRIPTION
feat(discovery): private classes and functions are auto-hidden now

fix(text): inherited @class now render correctly

If a function is namespaced and we can detect it, only functions with the same namespace can be returned (and, of those candidates, if any of them are marked as `---@private`, they are hidden too).

Also `---@class Foo : Bar` used to include the ` : Bar` text in the generated output. Now it's ignored as expected.